### PR TITLE
GTNWCM-25 Add getReader to WCMTextDocument and make WCMTextDocument

### DIFF
--- a/gatein-wcm-api/src/main/java/org/gatein/wcm/api/model/content/WCMBinaryDocument.java
+++ b/gatein-wcm-api/src/main/java/org/gatein/wcm/api/model/content/WCMBinaryDocument.java
@@ -78,12 +78,6 @@ public interface WCMBinaryDocument extends WCMObject {
 
     /**
      *
-     * @param size - Size of the file stored
-     */
-    void setSize(long size);
-
-    /**
-     *
      * @return This method returns name of file stored.
      */
     String getFileName();
@@ -98,12 +92,27 @@ public interface WCMBinaryDocument extends WCMObject {
      *
      * @return This method will return an InputStream of file stored.
      */
-    InputStream getContent();
+    InputStream getContentAsInputStream();
 
     /**
      *
      * @param content - InputStream with the binary content of the file.
      */
     void setContent(InputStream content);
+
+    /**
+     * Returns character encoding (e.g. {@code "UTF-8"}) which can be used to represent this {@link WCMBinaryDocument} as text.
+     * This method can return {@code null} if and only if this {@link WCMBinaryDocument} is not a text document.
+     *
+     * @return encoding or {@code null}
+     */
+    String getEncoding();
+
+    /**
+     * Sets character encoding (e.g. {@code "UTF-8"}) which can be used to represent this {@link WCMBinaryDocument} as text.
+     *
+     * @param encoding a valid encoding or {@code null} if this {@link WCMBinaryDocument} is not a text document
+     */
+    void setEncoding(String encoding);
 
 }

--- a/gatein-wcm-api/src/main/java/org/gatein/wcm/api/model/content/WCMTextDocument.java
+++ b/gatein-wcm-api/src/main/java/org/gatein/wcm/api/model/content/WCMTextDocument.java
@@ -22,6 +22,8 @@
  */
 package org.gatein.wcm.api.model.content;
 
+import java.io.Reader;
+
 /**
  *
  * Text content representation. <br />
@@ -37,31 +39,27 @@ package org.gatein.wcm.api.model.content;
  * @author <a href="mailto:lponce@redhat.com">Lucas Ponce</a>
  *
  */
-public interface WCMTextDocument extends WCMObject {
+public interface WCMTextDocument extends WCMBinaryDocument {
 
     /**
+     * Returns a {@link Reader} suitable for getting a text representation of this {@link WCMTextDocument}. Do not forget to
+     * call {@link Reader#close()} when you are finished with reading the returned {@link Reader}.
      *
-     * @return This method returns locale of the document. <br>
+     * @return a reader
      */
-    String getLocale();
-
-    /**
-     *
-     * @param locale Locale of the content
-     */
-    void setLocale(String locale);
-
-    /**
-     *
-     * @return This method returns the version of the content.
-     */
-    String getVersion();
+    Reader getContentAsReader();
 
     /**
      *
      * @return This method returns text of the content.
      */
-    String getContent();
+    void setContent(Reader reader);
+
+    /**
+     *
+     * @return This method returns text of the content.
+     */
+    String getContentAsString();
 
     /**
      *

--- a/gatein-wcm-api/src/main/java/org/gatein/wcm/api/services/WCMContentService.java
+++ b/gatein-wcm-api/src/main/java/org/gatein/wcm/api/services/WCMContentService.java
@@ -63,7 +63,7 @@ public interface WCMContentService {
      * @throws WCMContentIOException if any IO related problem with repository.
      * @throws WCMContentSecurityException if user has not been granted to create content under specified path.
      */
-    WCMTextDocument createTextDocument(String id, String locale, String path, String content) throws WCMContentException,
+    WCMTextDocument createTextDocument(String id, String locale, String path, String mimeType, String content) throws WCMContentException,
             WCMContentIOException, WCMContentSecurityException;
 
     /**
@@ -81,7 +81,7 @@ public interface WCMContentService {
      * @throws WCMContentIOException if any IO related problem with repository.
      * @throws WCMContentSecurityException if user has not been granted to create content under specified path.
      */
-    WCMTextDocument createTextDocument(String id, String path, String html) throws WCMContentException, WCMContentIOException,
+    WCMTextDocument createTextDocument(String id, String path, String mimeType, String content) throws WCMContentException, WCMContentIOException,
             WCMContentSecurityException;
 
     /**
@@ -111,7 +111,6 @@ public interface WCMContentService {
      *        String with format: / &lt;id&gt; / &lt;id&gt; / &lt;id&gt; <br>
      *        where "/" is the root of repository and &lt;id&gt; folders ID
      * @param mimeType - MIME Type content type
-     * @param size - Size's file.
      * @param fileName - Name's file.
      * @param content - Source of the file.
      * @return Content updated (if ok), null (if error).
@@ -119,7 +118,7 @@ public interface WCMContentService {
      * @throws WCMContentIOException if any IO related problem with repository.
      * @throws WCMContentSecurityException if user has not been granted to create content under specified path.
      */
-    WCMBinaryDocument createBinaryDocument(String id, String locale, String path, String mimeType, long size, String fileName,
+    WCMBinaryDocument createBinaryDocument(String id, String locale, String path, String mimeType, String fileName,
             InputStream content) throws WCMContentException, WCMContentIOException, WCMContentSecurityException;
 
     /**
@@ -132,7 +131,6 @@ public interface WCMContentService {
      *        String with format: / &lt;id&gt; / &lt;id&gt; / &lt;id&gt; <br>
      *        where "/" is the root of repository and &lt;id&gt; folders ID
      * @param mimeType - MIME Type content type
-     * @param size - Size's file.
      * @param fileName - Name's file.
      * @param content - Source of the file.
      * @return Content updated (if ok), null (if error).
@@ -140,7 +138,7 @@ public interface WCMContentService {
      * @throws WCMContentIOException if any IO related problem with repository.
      * @throws WCMContentSecurityException if user has not been granted to create content under specified path.
      */
-    WCMBinaryDocument createBinaryDocument(String id, String path, String mimeType, long size, String fileName,
+    WCMBinaryDocument createBinaryDocument(String id, String path, String mimeType, String fileName,
             InputStream content) throws WCMContentException, WCMContentIOException, WCMContentSecurityException;
 
     /**

--- a/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/model/WCMBinaryDocumentImpl.java
+++ b/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/model/WCMBinaryDocumentImpl.java
@@ -39,6 +39,7 @@ public class WCMBinaryDocumentImpl extends WCMObjectImpl implements WCMBinaryDoc
     protected long size;
     protected String fileName;
     protected InputStream content;
+    protected String encoding;
 
     @Override
     public String getLocale() {
@@ -66,7 +67,7 @@ public class WCMBinaryDocumentImpl extends WCMObjectImpl implements WCMBinaryDoc
     }
 
     @Override
-    public InputStream getContent() {
+    public InputStream getContentAsInputStream() {
         return content;
     }
 
@@ -88,7 +89,7 @@ public class WCMBinaryDocumentImpl extends WCMObjectImpl implements WCMBinaryDoc
         this.mimeType = mimeType;
     }
 
-    public void setSize(long size) {
+    void setSize(long size) {
         this.size = size;
     }
 
@@ -100,11 +101,16 @@ public class WCMBinaryDocumentImpl extends WCMObjectImpl implements WCMBinaryDoc
         this.content = content;
     }
 
-    // InputStream not included
+    /**
+     * Note that {@link #content} is not considered to compute the hash code.
+     *
+     * @see java.lang.Object#hashCode()
+     */
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
+        result = prime * result + ((encoding == null) ? 0 : encoding.hashCode());
         result = prime * result + ((fileName == null) ? 0 : fileName.hashCode());
         result = prime * result + ((locale == null) ? 0 : locale.hashCode());
         result = prime * result + ((mimeType == null) ? 0 : mimeType.hashCode());
@@ -113,7 +119,11 @@ public class WCMBinaryDocumentImpl extends WCMObjectImpl implements WCMBinaryDoc
         return result;
     }
 
-    // InputStream not included
+    /**
+     * Note that {@link #content} is not considered to compare.
+     *
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
@@ -123,6 +133,11 @@ public class WCMBinaryDocumentImpl extends WCMObjectImpl implements WCMBinaryDoc
         if (getClass() != obj.getClass())
             return false;
         WCMBinaryDocumentImpl other = (WCMBinaryDocumentImpl) obj;
+        if (encoding == null) {
+            if (other.encoding != null)
+                return false;
+        } else if (!encoding.equals(other.encoding))
+            return false;
         if (fileName == null) {
             if (other.fileName != null)
                 return false;
@@ -146,5 +161,21 @@ public class WCMBinaryDocumentImpl extends WCMObjectImpl implements WCMBinaryDoc
         } else if (!version.equals(other.version))
             return false;
         return true;
+    }
+
+    /**
+     * @see org.gatein.wcm.api.model.content.WCMBinaryDocument#getEncoding()
+     */
+    @Override
+    public String getEncoding() {
+        return encoding;
+    }
+
+    /**
+     * @see org.gatein.wcm.api.model.content.WCMBinaryDocument#setEncoding(java.lang.String)
+     */
+    @Override
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
     }
 }

--- a/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/model/WCMConstants.java
+++ b/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/model/WCMConstants.java
@@ -35,4 +35,14 @@ public class WCMConstants {
 
     public static final List<String> RESERVED_ENTRIES = Arrays.asList("jcr:system", "__acl", "__wcmstatus", "__wcmroles", "__comments", "__categories", "__properties" , "__relationships");
 
+    /**
+     * Size used when reading from or writing to binary or character streams.
+     */
+    public static final int BUFFER_SIZE = 128;
+
+    public static final String DEFAULT_ENCODING = "UTF-8";
+
+    public static final String MIME_TEXT_HTML = "text/html";
+    public static final String DEFAULT_MIME_TYPE = MIME_TEXT_HTML;
+
 }

--- a/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/model/WCMFolderImpl.java
+++ b/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/model/WCMFolderImpl.java
@@ -79,7 +79,7 @@ public class WCMFolderImpl extends WCMObjectImpl implements WCMFolder {
         if (binaryContent == null) {
             binaryContent = new ArrayList<WCMBinaryDocument>();
             for (WCMObject o : children) {
-                if (o instanceof WCMBinaryDocument)
+                if (o instanceof WCMBinaryDocument && !(o instanceof WCMTextDocument))
                     binaryContent.add((WCMBinaryDocument)o);
             }
         }

--- a/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/model/WCMTextDocumentImpl.java
+++ b/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/model/WCMTextDocumentImpl.java
@@ -22,37 +22,48 @@
  */
 package org.gatein.wcm.impl.model;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+
 import org.gatein.wcm.api.model.content.WCMTextDocument;
+import org.gatein.wcm.impl.util.ConvertibleByteArrayOutputStream;
 
 /**
  * @see {@link WCMTextDocument}
  * @author <a href="mailto:lponce@redhat.com">Lucas Ponce</a>
  *
  */
-public class WCMTextDocumentImpl extends WCMObjectImpl implements WCMTextDocument {
+public class WCMTextDocumentImpl extends WCMBinaryDocumentImpl implements WCMTextDocument {
 
-    protected String locale;
-    protected String version;
-    protected String content;
-
+    /**
+     * Sets {@link WCMBinaryDocumentImpl#size} properly.
+     *
+     * @see org.gatein.wcm.api.model.content.WCMTextDocument#getContentAsString()
+     */
     @Override
-    public String getLocale() {
-        return locale;
-    }
-
-    @Override
-    public String getVersion() {
-        return version;
-    }
-
-    @Override
-    public String getContent() {
-        return content;
-    }
-
-    @Override
-    public void setLocale(String locale) {
-        this.locale = locale;
+    public String getContentAsString() {
+        if (getSize() == 0) {
+            return null;
+        } else {
+            /* Using getSize() for StringBuilder capacity is actually worst case */
+            StringBuilder sb = new StringBuilder((int) getSize());
+            Reader r = getContentAsReader();
+            char[] buffer = new char[WCMConstants.BUFFER_SIZE];
+            int len = 0;
+            try {
+                while ((len = r.read(buffer)) >= 0) {
+                    sb.append(buffer, 0, len);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return sb.toString();
+        }
     }
 
     // Protected methods
@@ -60,48 +71,71 @@ public class WCMTextDocumentImpl extends WCMObjectImpl implements WCMTextDocumen
     protected WCMTextDocumentImpl() {
     }
 
-    protected void setVersion(String version) {
-        this.version = version;
-    }
-
     public void setContent(String content) {
-        this.content = content;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((content == null) ? 0 : content.hashCode());
-        result = prime * result + ((locale == null) ? 0 : locale.hashCode());
-        result = prime * result + ((version == null) ? 0 : version.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        WCMTextDocumentImpl other = (WCMTextDocumentImpl) obj;
         if (content == null) {
-            if (other.content != null)
-                return false;
-        } else if (!content.equals(other.content))
-            return false;
-        if (locale == null) {
-            if (other.locale != null)
-                return false;
-        } else if (!locale.equals(other.locale))
-            return false;
-        if (version == null) {
-            if (other.version != null)
-                return false;
-        } else if (!version.equals(other.version))
-            return false;
-        return true;
+            super.setContent((InputStream) null);
+        } else {
+            setContent(new StringReader(content));
+        }
     }
+
+    /**
+     * @see org.gatein.wcm.api.model.content.WCMTextDocument#getContentAsReader()
+     */
+    @Override
+    public Reader getContentAsReader() {
+        String encoding = getEncoding();
+        if (encoding == null) {
+            throw new IllegalStateException("Cannot create a " + Reader.class.getName() + " out of the underlying "
+                    + InputStream.class.getName() + " given that encoding is null.");
+        } else {
+            InputStream in = getContentAsInputStream();
+            try {
+                return new InputStreamReader(in, encoding);
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /**
+     * Sets {@link WCMBinaryDocumentImpl#size} properly.
+     *
+     * @see org.gatein.wcm.api.model.content.WCMTextDocument#setContent(java.io.Reader)
+     */
+    @Override
+    public void setContent(Reader reader) {
+        if (reader == null) {
+            super.setContent((InputStream) null);
+        } else {
+            String encoding = getEncoding();
+            if (encoding == null) {
+                this.encoding = WCMConstants.DEFAULT_ENCODING;
+            }
+
+            ConvertibleByteArrayOutputStream out = null;
+            OutputStreamWriter w = null;
+            try {
+                out = new ConvertibleByteArrayOutputStream();
+                w = new OutputStreamWriter(out, encoding);
+                char[] buffer = new char[WCMConstants.BUFFER_SIZE];
+                int len = 0;
+                while ((len = reader.read(buffer)) >= 0) {
+                    w.write(buffer, 0, len);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } finally {
+                if (w != null) {
+                    try {
+                        w.close();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+            setContent(out.createInputStream());
+        }
+    }
+
 }

--- a/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/services/commands/UpdateCommand.java
+++ b/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/services/commands/UpdateCommand.java
@@ -27,7 +27,6 @@ import java.util.List;
 import javax.jcr.AccessDeniedException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.jcr.Value;
 
 import org.gatein.wcm.api.model.content.WCMBinaryDocument;
 import org.gatein.wcm.api.model.content.WCMObject;
@@ -80,7 +79,7 @@ public class UpdateCommand {
             throw new WCMContentException("Parameter doc cannot be null or empty");
         if (doc.getLocale() == null || "".equals(doc.getLocale()))
             throw new WCMContentException("Parameter doc.getLocale() cannot be null or empty");
-        if (doc.getContent() == null || "".equals(doc.getContent()))
+        if (doc.getContentAsInputStream() == null || doc.getSize() == 0)
             throw new WCMContentException("Parameter doc.getContent() cannot be null or empty");
 
         // Check if the current JCR Session is valid
@@ -102,8 +101,7 @@ public class UpdateCommand {
         // Updating existing Node
         try {
 
-            Value content = jcr.jcrValue(doc.getContent());
-            jcr.updateTextNode(path, doc.getLocale(), content);
+            jcr.updateBinaryNode(path, doc);
 
             WCMObject obj = factory.getContent(path);
             if (obj instanceof WCMTextDocument)
@@ -241,7 +239,7 @@ public class UpdateCommand {
             throw new WCMContentException("Parameter doc.getSize() cannot be 0");
         if (doc.getFileName() == null || "".endsWith(doc.getFileName()))
             throw new WCMContentException("Parameter doc.getFileName() cannot be null or empty");
-        if (doc.getContent() == null)
+        if (doc.getContentAsInputStream() == null)
             throw new WCMContentException("Parameter content in InputStream cannot be null");
 
         // Check if the current JCR Session is valid

--- a/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/util/ConvertibleByteArrayOutputStream.java
+++ b/gatein-wcm-impl/src/main/java/org/gatein/wcm/impl/util/ConvertibleByteArrayOutputStream.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.gatein.wcm.impl.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+/**
+ * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
+ *
+ */
+public class ConvertibleByteArrayOutputStream extends ByteArrayOutputStream {
+
+    public ConvertibleByteArrayOutputStream() {
+    }
+
+    public ConvertibleByteArrayOutputStream(int size) {
+        super(size);
+    }
+
+    public ByteArrayInputStream createInputStream() {
+        return new ByteArrayInputStream(buf, 0, size());
+    }
+
+}

--- a/gatein-wcm-integration-tests/src/test/java/org/gatein/wcm/api/SecurityTest.java
+++ b/gatein-wcm-integration-tests/src/test/java/org/gatein/wcm/api/SecurityTest.java
@@ -306,11 +306,11 @@ public class SecurityTest {
 
         // Writing
         cs = repos.createContentSession("user1", "gtn");
-        cs.createTextDocument("eu1", "/europe", "This is a document written by user1");
+        cs.createTextDocument("eu1", "/europe", "text/plain", "This is a document written by user1");
 
         boolean fail = false;
         try {
-            cs.createTextDocument("eu2", "/america", "This is a document written by user1");
+            cs.createTextDocument("eu2", "/america", "text/plain", "This is a document written by user1");
         } catch (Exception expected) {
             // Expected, We don't have rights to access /america
             fail = true;
@@ -321,11 +321,11 @@ public class SecurityTest {
             Assert.assertFalse(true);
 
         cs = repos.createContentSession("user3", "gtn");
-        cs.createTextDocument("us1", "/america", "This is a document written by user3");
+        cs.createTextDocument("us1", "/america", "text/plain", "This is a document written by user3");
 
         fail = false;
         try {
-            cs.createTextDocument("us2", "/europe", "This is a document written by user3");
+            cs.createTextDocument("us2", "/europe", "text/plain", "This is a document written by user3");
         } catch (Exception expected) {
             // Expected, We don't have rights to access /america
             fail = true;
@@ -340,14 +340,14 @@ public class SecurityTest {
         WCMTextDocument doc = (WCMTextDocument) cs.getContent("/america/us1");
         Assert.assertEquals("us1", doc.getId());
         Assert.assertEquals("/america/us1", doc.getPath());
-        Assert.assertEquals("This is a document written by user3", doc.getContent());
+        Assert.assertEquals("This is a document written by user3", doc.getContentAsString());
         cs.closeSession();
 
         cs = repos.createContentSession("user3", "gtn");
         doc = (WCMTextDocument) cs.getContent("/europe/eu1");
         Assert.assertEquals("eu1", doc.getId());
         Assert.assertEquals("/europe/eu1", doc.getPath());
-        Assert.assertEquals("This is a document written by user1", doc.getContent());
+        Assert.assertEquals("This is a document written by user1", doc.getContentAsString());
         cs.closeSession();
 
         // JCR
@@ -405,7 +405,7 @@ public class SecurityTest {
 
         // Writing
         cs = repos.createContentSession("user1", "gtn");
-        cs.createTextDocument("eu1", "/europe", "This is a document written by user1");
+        cs.createTextDocument("eu1", "/europe", "text/plain", "This is a document written by user1");
         cs.createContentAce("/europe", "otherrole", WCMPrincipalType.ROLE, WCMPermissionType.READ);
         boolean fail = false;
         try {
@@ -421,7 +421,7 @@ public class SecurityTest {
 
         fail = false;
         try {
-            cs.createTextDocument("eu2", "/america", "This is a document written by user1");
+            cs.createTextDocument("eu2", "/america", "text/plain", "This is a document written by user1");
         } catch (Exception expected) {
             // Expected, We don't have rights to access /america
             fail = true;
@@ -432,11 +432,11 @@ public class SecurityTest {
             Assert.assertFalse(true);
 
         cs = repos.createContentSession("user3", "gtn");
-        cs.createTextDocument("us1", "/america", "This is a document written by user3");
+        cs.createTextDocument("us1", "/america", "text/plain", "This is a document written by user3");
 
         fail = false;
         try {
-            cs.createTextDocument("us2", "/europe", "This is a document written by user3");
+            cs.createTextDocument("us2", "/europe", "text/plain", "This is a document written by user3");
         } catch (Exception expected) {
             // Expected, We don't have rights to access /america
             fail = true;
@@ -451,14 +451,14 @@ public class SecurityTest {
         WCMTextDocument doc = (WCMTextDocument) cs.getContent("/america/us1");
         Assert.assertEquals("us1", doc.getId());
         Assert.assertEquals("/america/us1", doc.getPath());
-        Assert.assertEquals("This is a document written by user3", doc.getContent());
+        Assert.assertEquals("This is a document written by user3", doc.getContentAsString());
         cs.closeSession();
 
         cs = repos.createContentSession("user3", "gtn");
         doc = (WCMTextDocument) cs.getContent("/europe/eu1");
         Assert.assertEquals("eu1", doc.getId());
         Assert.assertEquals("/europe/eu1", doc.getPath());
-        Assert.assertEquals("This is a document written by user1", doc.getContent());
+        Assert.assertEquals("This is a document written by user1", doc.getContentAsString());
         cs.closeSession();
 
         // JCR

--- a/gatein-wcm-integration-tests/src/test/java/org/gatein/wcm/api/WCMContentServiceTest.java
+++ b/gatein-wcm-integration-tests/src/test/java/org/gatein/wcm/api/WCMContentServiceTest.java
@@ -75,14 +75,14 @@ public class WCMContentServiceTest {
     public void createTextDocument() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument text1 = cs.createTextDocument("text1", "en", "/", "This is a content");
+        WCMTextDocument text1 = cs.createTextDocument("text1", "en", "/", "text/plain", "This is a content");
 
         Assert.assertFalse(text1 == null);
         Assert.assertEquals("text1", text1.getId());
         Assert.assertEquals("/", text1.getParentPath());
         Assert.assertEquals("/text1", text1.getPath());
         Assert.assertEquals("en", text1.getLocale());
-        Assert.assertEquals("This is a content", text1.getContent());
+        Assert.assertEquals("This is a content", text1.getContentAsString());
         Assert.assertEquals("admin", text1.getCreatedBy());
 
         cs.deleteContent("/text1");
@@ -93,34 +93,34 @@ public class WCMContentServiceTest {
     public void createTextDocumentSameIdSeveralLocales() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument text2 = cs.createTextDocument("text2", "en", "/", "This is a content");
+        WCMTextDocument text2 = cs.createTextDocument("text2", "en", "/", "text/plain", "This is a content");
 
         Assert.assertFalse(text2 == null);
         Assert.assertEquals("text2", text2.getId());
         Assert.assertEquals("/", text2.getParentPath());
         Assert.assertEquals("/text2", text2.getPath());
         Assert.assertEquals("en", text2.getLocale());
-        Assert.assertEquals("This is a content", text2.getContent());
+        Assert.assertEquals("This is a content", text2.getContentAsString());
         Assert.assertEquals("admin", text2.getCreatedBy());
 
-        WCMTextDocument text2_es = cs.createTextDocument("text2", "es", "/", "Este es un contenido");
+        WCMTextDocument text2_es = cs.createTextDocument("text2", "es", "/", "text/plain", "Este es un contenido");
 
         Assert.assertFalse(text2_es == null);
         Assert.assertEquals("text2__es", text2_es.getId());
         Assert.assertEquals("/", text2_es.getParentPath());
         Assert.assertEquals("/text2__es", text2_es.getPath());
         Assert.assertEquals("es", text2_es.getLocale());
-        Assert.assertEquals("Este es un contenido", text2_es.getContent());
+        Assert.assertEquals("Este es un contenido", text2_es.getContentAsString());
         Assert.assertEquals("admin", text2_es.getCreatedBy());
 
-        WCMTextDocument text2_fr = cs.createTextDocument("text2", "fr", "/", "C'est un contenu");
+        WCMTextDocument text2_fr = cs.createTextDocument("text2", "fr", "/", "text/plain", "C'est un contenu");
 
         Assert.assertFalse(text2_fr == null);
         Assert.assertEquals("text2__fr", text2_fr.getId());
         Assert.assertEquals("/", text2_fr.getParentPath());
         Assert.assertEquals("/text2__fr", text2_fr.getPath());
         Assert.assertEquals("fr", text2_fr.getLocale());
-        Assert.assertEquals("C'est un contenu", text2_fr.getContent());
+        Assert.assertEquals("C'est un contenu", text2_fr.getContentAsString());
         Assert.assertEquals("admin", text2_fr.getCreatedBy());
 
         cs.deleteContent("/text2");
@@ -133,19 +133,19 @@ public class WCMContentServiceTest {
     public void createTextDocumentFailsIfSameIdAndSameLocale() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument text3 = cs.createTextDocument("text3", "en", "/", "This is a content");
+        WCMTextDocument text3 = cs.createTextDocument("text3", "en", "/", "text/plain", "This is a content");
 
         Assert.assertFalse(text3 == null);
         Assert.assertEquals("text3", text3.getId());
         Assert.assertEquals("/", text3.getParentPath());
         Assert.assertEquals("/text3", text3.getPath());
         Assert.assertEquals("en", text3.getLocale());
-        Assert.assertEquals("This is a content", text3.getContent());
+        Assert.assertEquals("This is a content", text3.getContentAsString());
         Assert.assertEquals("admin", text3.getCreatedBy());
 
         boolean fail = false;
         try {
-            cs.createTextDocument("text3", "en", "/", "This is a repeated content");
+            cs.createTextDocument("text3", "en", "/", "text/plain", "This is a repeated content");
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
@@ -164,7 +164,7 @@ public class WCMContentServiceTest {
 
         boolean fail = false;
         try {
-            cs.createTextDocument("dummy", "en", "/thispathdoentexist", "This is a dummy");
+            cs.createTextDocument("dummy", "en", "/thispathdoentexist", "text/plain", "This is a dummy");
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
@@ -181,7 +181,7 @@ public class WCMContentServiceTest {
 
         boolean fail = false;
         try {
-            cs.createTextDocument("dummy", "en", "/thispathdoentexist", "This is a dummy");
+            cs.createTextDocument("dummy", "en", "/thispathdoentexist", "text/plain", "This is a dummy");
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
@@ -196,53 +196,46 @@ public class WCMContentServiceTest {
     public void createTextDocumentFailsIfNullArguments() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        boolean fail = false;
         try {
-            cs.createTextDocument("dummy", "en", "/thispathdoentexist", null);
-        } catch (Exception e) {
-            // Expected to fail...
-            fail = true;
+            cs.createTextDocument("dummy", "en", "/thispathdoentexist", "text/plain", null);
+            Assert.fail("Exception expected.");
+        } catch (Exception expected) {
         }
 
         try {
-            cs.createTextDocument("dummy", "en", null, "Test");
-        } catch (Exception e) {
-            // Expected to fail...
-            fail = true;
+            cs.createTextDocument("dummy", "en", null, "text/plain", "Test");
+            Assert.fail("Exception expected.");
+        } catch (Exception expected) {
         }
 
         try {
-            cs.createTextDocument("dummy", null, "/thispathdoentexist", "Test");
-        } catch (Exception e) {
-            // Expected to fail...
-            fail = true;
+            cs.createTextDocument("dummy", null, "/thispathdoentexist", "text/plain", "Test");
+            Assert.fail("Exception expected.");
+        } catch (Exception expected) {
         }
 
         try {
-            cs.createTextDocument(null, "en", "/thispathdoentexist", "Test");
-        } catch (Exception e) {
-            // Expected to fail...
-            fail = true;
+            cs.createTextDocument(null, "en", "/thispathdoentexist", "text/plain", "Test");
+            Assert.fail("Exception expected.");
+        } catch (Exception expected) {
         }
 
         cs.closeSession();
 
-        if (!fail)
-            Assert.assertFalse(true);
     }
 
     @Test
     public void createTextDocumentDefaultLocale() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument text4 = cs.createTextDocument("text4", "/", "This is a content");
+        WCMTextDocument text4 = cs.createTextDocument("text4", "/", "text/plain", "This is a content");
 
         Assert.assertFalse(text4 == null);
         Assert.assertEquals("text4", text4.getId());
         Assert.assertEquals("/", text4.getParentPath());
         Assert.assertEquals("/text4", text4.getPath());
         Assert.assertEquals(repos.getDefaultLocale(), text4.getLocale());
-        Assert.assertEquals("This is a content", text4.getContent());
+        Assert.assertEquals("This is a content", text4.getContentAsString());
         Assert.assertEquals("admin", text4.getCreatedBy());
 
         cs.deleteContent("/text4");
@@ -277,12 +270,12 @@ public class WCMContentServiceTest {
     public void cantCreateContentUnderNotFolder() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("text5", "/", "This is a content");
+        cs.createTextDocument("text5", "/", "text/plain", "This is a content");
 
         boolean fail = false;
 
         try {
-            cs.createTextDocument("dummy", "/text5", "Dummy text");
+            cs.createTextDocument("dummy", "/text5", "text/plain", "Dummy text");
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
@@ -371,7 +364,7 @@ public class WCMContentServiceTest {
 
         cs = repos.createContentSession("admin", "admin");
 
-        WCMBinaryDocument binary1 = cs.createBinaryDocument("binary1", "en", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument binary1 = cs.createBinaryDocument("binary1", "en", "/", mimeType, fileName, content);
 
         Assert.assertFalse(binary1 == null);
         Assert.assertEquals("binary1", binary1.getId());
@@ -382,9 +375,10 @@ public class WCMContentServiceTest {
         Assert.assertEquals(fileName, binary1.getFileName());
         Assert.assertEquals(size, binary1.getSize());
         Assert.assertEquals(mimeType, binary1.getMimeType());
-        Assert.assertFalse(binary1.getContent() == null);
+        InputStream in = binary1.getContentAsInputStream();
+        Assert.assertNotNull(in);
 
-        byte[] file = toByteArray(binary1.getContent());
+        byte[] file = toByteArray(in);
         Assert.assertEquals(binary1.getSize(), file.length);
 
         cs.deleteContent("/binary1");
@@ -401,7 +395,7 @@ public class WCMContentServiceTest {
 
         cs = repos.createContentSession("admin", "admin");
 
-        WCMBinaryDocument binary2 = cs.createBinaryDocument("binary2", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument binary2 = cs.createBinaryDocument("binary2", "/", mimeType, fileName, content);
 
         Assert.assertFalse(binary2 == null);
         Assert.assertEquals("binary2", binary2.getId());
@@ -412,9 +406,10 @@ public class WCMContentServiceTest {
         Assert.assertEquals(fileName, binary2.getFileName());
         Assert.assertEquals(size, binary2.getSize());
         Assert.assertEquals(mimeType, binary2.getMimeType());
-        Assert.assertFalse(binary2.getContent() == null);
+        InputStream in = binary2.getContentAsInputStream();
+        Assert.assertNotNull(in);
 
-        byte[] file = toByteArray(binary2.getContent());
+        byte[] file = toByteArray(in);
         Assert.assertEquals(binary2.getSize(), file.length);
 
         cs.deleteContent("/binary2");
@@ -433,42 +428,42 @@ public class WCMContentServiceTest {
 
         boolean fail = false;
         try {
-            cs.createBinaryDocument("dummy", "/thispathdoesntexist", mimeType, size, fileName, null);
+            cs.createBinaryDocument("dummy", "/thispathdoesntexist", mimeType, fileName, null);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
         }
 
         try {
-            cs.createBinaryDocument("dummy", "/thispathdoesntexist", mimeType, size, null, content);
+            cs.createBinaryDocument("dummy", "/thispathdoesntexist", mimeType, null, content);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
         }
 
         try {
-            cs.createBinaryDocument("dummy", "/thispathdoesntexist", mimeType, 0, fileName, content);
+            cs.createBinaryDocument("dummy", "/thispathdoesntexist", mimeType, fileName, content);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
         }
 
         try {
-            cs.createBinaryDocument("dummy", "/thispathdoesntexist", null, size, fileName, content);
+            cs.createBinaryDocument("dummy", "/thispathdoesntexist", null, fileName, content);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
         }
 
         try {
-            cs.createBinaryDocument("dummy", null, mimeType, size, fileName, content);
+            cs.createBinaryDocument("dummy", null, mimeType, fileName, content);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
         }
 
         try {
-            cs.createBinaryDocument(null, "/thispathdoesntexist", mimeType, size, fileName, content);
+            cs.createBinaryDocument(null, "/thispathdoesntexist", mimeType, fileName, content);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
@@ -491,7 +486,7 @@ public class WCMContentServiceTest {
 
         boolean fail = false;
         try {
-            cs.createBinaryDocument("dummy", "/thispathdoesntexist", mimeType, size, fileName, content);
+            cs.createBinaryDocument("dummy", "/thispathdoesntexist", mimeType, fileName, content);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
@@ -512,7 +507,7 @@ public class WCMContentServiceTest {
 
         cs = repos.createContentSession("admin", "admin");
 
-        WCMBinaryDocument binary3 = cs.createBinaryDocument("binary3", "en", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument binary3 = cs.createBinaryDocument("binary3", "en", "/", mimeType, fileName, content);
 
         Assert.assertFalse(binary3 == null);
         Assert.assertEquals("binary3", binary3.getId());
@@ -523,14 +518,15 @@ public class WCMContentServiceTest {
         Assert.assertEquals(fileName, binary3.getFileName());
         Assert.assertEquals(size, binary3.getSize());
         Assert.assertEquals(mimeType, binary3.getMimeType());
-        Assert.assertFalse(binary3.getContent() == null);
+        InputStream in = binary3.getContentAsInputStream();
+        Assert.assertNotNull(in);
 
-        byte[] file = toByteArray(binary3.getContent());
+        byte[] file = toByteArray(in);
         Assert.assertEquals(binary3.getSize(), file.length);
 
         boolean fail = false;
         try {
-            cs.createBinaryDocument("binary3", "en", "/", mimeType, size, fileName, content);
+            cs.createBinaryDocument("binary3", "en", "/", mimeType, fileName, content);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
@@ -553,7 +549,7 @@ public class WCMContentServiceTest {
 
         cs = repos.createContentSession("admin", "admin");
 
-        WCMBinaryDocument binary4 = cs.createBinaryDocument("binary4", "en", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument binary4 = cs.createBinaryDocument("binary4", "en", "/", mimeType, fileName, content);
 
         Assert.assertFalse(binary4 == null);
         Assert.assertEquals("binary4", binary4.getId());
@@ -564,16 +560,17 @@ public class WCMContentServiceTest {
         Assert.assertEquals(fileName, binary4.getFileName());
         Assert.assertEquals(size, binary4.getSize());
         Assert.assertEquals(mimeType, binary4.getMimeType());
-        Assert.assertFalse(binary4.getContent() == null);
+        InputStream in = binary4.getContentAsInputStream();
+        Assert.assertNotNull(in);
 
-        byte[] file = toByteArray(binary4.getContent());
+        byte[] file = toByteArray(in);
         Assert.assertEquals(binary4.getSize(), file.length);
 
         // To re-read the same InputStream
         content = (FileInputStream) Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("/GateIn-UserGuide-v3.5.pdf");
 
-        WCMBinaryDocument binary4_es = cs.createBinaryDocument("binary4", "es", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument binary4_es = cs.createBinaryDocument("binary4", "es", "/", mimeType, fileName, content);
 
         Assert.assertFalse(binary4_es == null);
         Assert.assertEquals("binary4__es", binary4_es.getId());
@@ -584,16 +581,17 @@ public class WCMContentServiceTest {
         Assert.assertEquals(fileName, binary4_es.getFileName());
         Assert.assertEquals(size, binary4_es.getSize());
         Assert.assertEquals(mimeType, binary4_es.getMimeType());
-        Assert.assertFalse(binary4_es.getContent() == null);
+        InputStream inEs = binary4_es.getContentAsInputStream();
+        Assert.assertNotNull(inEs);
 
-        byte[] file_es = toByteArray(binary4_es.getContent());
+        byte[] file_es = toByteArray(inEs);
         Assert.assertEquals(binary4_es.getSize(), file_es.length);
 
         // To re-read the same InputStream
         content = (FileInputStream) Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("/GateIn-UserGuide-v3.5.pdf");
 
-        WCMBinaryDocument binary4_fr = cs.createBinaryDocument("binary4", "fr", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument binary4_fr = cs.createBinaryDocument("binary4", "fr", "/", mimeType, fileName, content);
 
         Assert.assertFalse(binary4_fr == null);
         Assert.assertEquals("binary4__fr", binary4_fr.getId());
@@ -604,9 +602,10 @@ public class WCMContentServiceTest {
         Assert.assertEquals(fileName, binary4_fr.getFileName());
         Assert.assertEquals(size, binary4_fr.getSize());
         Assert.assertEquals(mimeType, binary4_fr.getMimeType());
-        Assert.assertFalse(binary4_fr.getContent() == null);
+        InputStream inFr = binary4_fr.getContentAsInputStream();
+        Assert.assertNotNull(inFr);
 
-        byte[] file_fr = toByteArray(binary4_fr.getContent());
+        byte[] file_fr = toByteArray(inFr);
         Assert.assertEquals(binary4_fr.getSize(), file_fr.length);
 
         cs.deleteContent("/binary4");
@@ -627,7 +626,7 @@ public class WCMContentServiceTest {
 
         boolean fail = false;
         try {
-            cs.createBinaryDocument("dummy", "en", "/thispathdoentexist", mimeType, size, fileName, content);
+            cs.createBinaryDocument("dummy", "en", "/thispathdoentexist", mimeType, fileName, content);
         } catch (Exception e) {
             // Expected to fail...
             fail = true;
@@ -642,7 +641,7 @@ public class WCMContentServiceTest {
     public void getContentWithTextDocuments() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument text6 = cs.createTextDocument("text6", "en", "/", "This is a content");
+        WCMTextDocument text6 = cs.createTextDocument("text6", "en", "/", "text/plain", "This is a content");
         WCMObject obj = cs.getContent("/text6");
 
         Assert.assertFalse(text6 == null);
@@ -662,7 +661,7 @@ public class WCMContentServiceTest {
 
         cs = repos.createContentSession("admin", "admin");
 
-        WCMBinaryDocument binary5 = cs.createBinaryDocument("binary5", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument binary5 = cs.createBinaryDocument("binary5", "/", mimeType, fileName, content);
         WCMObject obj = cs.getContent("/binary5");
 
         Assert.assertFalse(binary5 == null);
@@ -698,8 +697,8 @@ public class WCMContentServiceTest {
 
         WCMFolder folder4 = cs.createFolder("folder4", "/");
         WCMFolder folder41 = cs.createFolder("folder41", folder4.getPath());
-        WCMTextDocument text411 = cs.createTextDocument("text411", folder41.getPath(), "This is text 411");
-        WCMBinaryDocument binary411 = cs.createBinaryDocument("binary411", folder41.getPath(), mimeType, size, fileName,
+        WCMTextDocument text411 = cs.createTextDocument("text411", folder41.getPath(), "text/plain", "This is text 411");
+        WCMBinaryDocument binary411 = cs.createBinaryDocument("binary411", folder41.getPath(), mimeType, fileName,
                 content);
 
         // folder4 and folder41 are not updated so we need to use getContent() for children
@@ -730,8 +729,8 @@ public class WCMContentServiceTest {
     public void createRelationship() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("rel1", "en", "/", "This is a content for a relationship");
-        cs.createTextDocument("rel2", "es", "/", "Este es otro contenido para una relación");
+        cs.createTextDocument("rel1", "en", "/", "text/plain", "This is a content for a relationship");
+        cs.createTextDocument("rel2", "es", "/", "text/plain", "Este es otro contenido para una relación");
         cs.createContentRelation("/rel1", "/rel2", "es");
         WCMObject obj = cs.getContent("/rel1", "es");
         Assert.assertFalse(obj == null);
@@ -740,7 +739,7 @@ public class WCMContentServiceTest {
         Assert.assertEquals("rel2", text.getId());
         Assert.assertEquals("/", text.getParentPath());
         Assert.assertEquals("/rel2", text.getPath());
-        Assert.assertEquals("Este es otro contenido para una relación", text.getContent());
+        Assert.assertEquals("Este es otro contenido para una relación", text.getContentAsString());
         Assert.assertEquals("es", text.getLocale());
 
         cs.deleteContent("/rel1");
@@ -756,12 +755,12 @@ public class WCMContentServiceTest {
         cs.createFolder("en", "/");
         cs.createFolder("noticias", "/es");
         cs.createFolder("news", "/en");
-        cs.createTextDocument("not1", "es", "/es/noticias", "Esta es la noticia 1");
-        cs.createTextDocument("not2", "es", "/es/noticias", "Esta es la noticia 2");
-        cs.createTextDocument("not3", "es", "/es/noticias", "Esta es la noticia 3");
-        cs.createTextDocument("new1", "en", "/en/news", "This is news 1");
-        cs.createTextDocument("new2", "en", "/en/news", "This is news 2");
-        cs.createTextDocument("new3", "en", "/en/news", "This is news 3");
+        cs.createTextDocument("not1", "es", "/es/noticias", "text/plain", "Esta es la noticia 1");
+        cs.createTextDocument("not2", "es", "/es/noticias", "text/plain", "Esta es la noticia 2");
+        cs.createTextDocument("not3", "es", "/es/noticias", "text/plain", "Esta es la noticia 3");
+        cs.createTextDocument("new1", "en", "/en/news", "text/plain", "This is news 1");
+        cs.createTextDocument("new2", "en", "/en/news", "text/plain", "This is news 2");
+        cs.createTextDocument("new3", "en", "/en/news", "text/plain", "This is news 3");
         cs.createContentRelation("/es", "/en", "en");
         WCMObject obj = cs.getContent("/es", "en");
         Assert.assertFalse(obj == null);
@@ -811,7 +810,7 @@ public class WCMContentServiceTest {
     public void createRelationshipFailsIfPathDoesntExist() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("fail", "es", "/", "Esta es un contenido de test");
+        cs.createTextDocument("fail", "es", "/", "text/plain", "Esta es un contenido de test");
 
         boolean fail = false;
         try {
@@ -839,7 +838,7 @@ public class WCMContentServiceTest {
     public void updateTextDocument() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument text = cs.createTextDocument("update1", "es", "/", "Esta es un contenido de test");
+        WCMTextDocument text = cs.createTextDocument("update1", "es", "/", "text/plain", "Esta es un contenido de test");
         text.setLocale("en");
         text.setContent("This is an update for a content");
         text = cs.updateTextDocument("/update1", text);
@@ -849,7 +848,7 @@ public class WCMContentServiceTest {
         Assert.assertEquals("/", text.getParentPath());
         Assert.assertEquals("/update1", text.getPath());
         Assert.assertEquals("en", text.getLocale());
-        Assert.assertEquals("This is an update for a content", text.getContent());
+        Assert.assertEquals("This is an update for a content", text.getContentAsString());
 
         cs.deleteContent("/update1");
         cs.closeSession();
@@ -859,7 +858,7 @@ public class WCMContentServiceTest {
     public void updateTextDocumentFailsIfNullArguments() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument text = cs.createTextDocument("update2", "es", "/", "Esta es un contenido de test");
+        WCMTextDocument text = cs.createTextDocument("update2", "es", "/", "text/plain", "Esta es un contenido de test");
         text.setLocale("en");
         text.setContent("This is an update for a content");
 
@@ -888,7 +887,7 @@ public class WCMContentServiceTest {
         }
 
         try {
-            text.setContent(null);
+            text.setContent((InputStream)null);
             cs.updateTextDocument("/update2", text);
         } catch (Exception e) {
             // Expected to fail...
@@ -907,7 +906,7 @@ public class WCMContentServiceTest {
     public void updateTextDocumentFailsIfPathDoesntExist() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument text = cs.createTextDocument("update3", "es", "/", "Esta es un contenido de test");
+        WCMTextDocument text = cs.createTextDocument("update3", "es", "/", "text/plain", "Esta es un contenido de test");
         text.setLocale("en");
         text.setContent("This is an update for a content");
 
@@ -930,8 +929,8 @@ public class WCMContentServiceTest {
     public void updateTextDocumentWithRelationships() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("update4es", "es", "/", "Este es un contenido de test");
-        WCMTextDocument updated = cs.createTextDocument("update4en", "en", "/", "This is a test content");
+        cs.createTextDocument("update4es", "es", "/", "text/plain", "Este es un contenido de test");
+        WCMTextDocument updated = cs.createTextDocument("update4en", "en", "/", "text/plain", "This is a test content");
         cs.createContentRelation("/update4es", "/update4en", "en");
 
         updated.setContent("This is an UPDATE of update4en");
@@ -951,14 +950,14 @@ public class WCMContentServiceTest {
     public void updateContentName() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument doc = cs.createTextDocument("testupdate1", "/", "This is a test content");
+        WCMTextDocument doc = cs.createTextDocument("testupdate1", "/", "text/plain", "This is a test content");
         Assert.assertEquals("testupdate1", doc.getId());
         Assert.assertEquals("/testupdate1", doc.getPath());
 
         doc = (WCMTextDocument)cs.updateContentName("/testupdate1", "newnamemodified");
         Assert.assertEquals("newnamemodified", doc.getId());
         Assert.assertEquals("/newnamemodified", doc.getPath());
-        Assert.assertEquals("This is a test content", doc.getContent());
+        Assert.assertEquals("This is a test content", doc.getContentAsString());
 
         cs.deleteContent("/newnamemodified");
         cs.closeSession();
@@ -992,7 +991,7 @@ public class WCMContentServiceTest {
 
         cs = repos.createContentSession("admin", "admin");
 
-        WCMBinaryDocument bin = cs.createBinaryDocument("testupdate3", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument bin = cs.createBinaryDocument("testupdate3", "/", mimeType, fileName, content);
         Assert.assertEquals("testupdate3", bin.getId());
         Assert.assertEquals("/testupdate3", bin.getPath());
         Assert.assertEquals(size, bin.getSize());
@@ -1012,30 +1011,30 @@ public class WCMContentServiceTest {
 
         WCMTextDocument doc, doc2;
 
-        cs.createTextDocument("testupdate4", "/", "This is a test content");
+        cs.createTextDocument("testupdate4", "/", "text/plain", "This is a test content");
         cs.createContentAce("/testupdate4", "admin", WCMPrincipalType.USER, WCMPermissionType.ALL);
         cs.createContentComment("/testupdate4", "This is a test comment");
-        cs.createTextDocument("testupdate4", "es", "/", "Este es un contenido relacionado");
+        cs.createTextDocument("testupdate4", "es", "/", "text/plain", "Este es un contenido relacionado");
         doc = (WCMTextDocument)cs.createContentProperty("/testupdate4", "test", "test property");
         doc2 = (WCMTextDocument)cs.getContent("/testupdate4", "es");
 
         Assert.assertEquals("testupdate4", doc.getId());
         Assert.assertEquals("/testupdate4", doc.getPath());
-        Assert.assertEquals("This is a test content", doc.getContent());
+        Assert.assertEquals("This is a test content", doc.getContentAsString());
         Assert.assertEquals(1, doc.getAcl().getAces().size());
         Assert.assertEquals(1, doc.getComments().size());
         Assert.assertEquals("test property", doc.getProperties().get("test"));
-        Assert.assertEquals("Este es un contenido relacionado", doc2.getContent());
+        Assert.assertEquals("Este es un contenido relacionado", doc2.getContentAsString());
 
         doc = (WCMTextDocument)cs.updateContentName("/testupdate4", "newnamemodified4");
         doc2 = (WCMTextDocument)cs.getContent("/newnamemodified4", "es");
         Assert.assertEquals("newnamemodified4", doc.getId());
         Assert.assertEquals("/newnamemodified4", doc.getPath());
-        Assert.assertEquals("This is a test content", doc.getContent());
+        Assert.assertEquals("This is a test content", doc.getContentAsString());
         Assert.assertEquals(1, doc.getAcl().getAces().size());
         Assert.assertEquals(1, doc.getComments().size());
         Assert.assertEquals("test property", doc.getProperties().get("test"));
-        Assert.assertEquals("Este es un contenido relacionado", doc2.getContent());
+        Assert.assertEquals("Este es un contenido relacionado", doc2.getContentAsString());
 
         cs.deleteContent(doc.getPath());
         cs.deleteContent(doc2.getPath());
@@ -1092,15 +1091,15 @@ public class WCMContentServiceTest {
         WCMTextDocument doc;
 
         cs.createFolder("updatefolder1", "/");
-        doc = cs.createTextDocument("testupdate5", "/", "This is a test content");
+        doc = cs.createTextDocument("testupdate5", "/", "text/plain", "This is a test content");
         Assert.assertEquals("testupdate5", doc.getId());
         Assert.assertEquals("/testupdate5", doc.getPath());
-        Assert.assertEquals("This is a test content", doc.getContent());
+        Assert.assertEquals("This is a test content", doc.getContentAsString());
 
         doc = (WCMTextDocument)cs.updateContentPath("/testupdate5", "/updatefolder1");
         Assert.assertEquals("testupdate5", doc.getId());
         Assert.assertEquals("/updatefolder1/testupdate5", doc.getPath());
-        Assert.assertEquals("This is a test content", doc.getContent());
+        Assert.assertEquals("This is a test content", doc.getContentAsString());
 
         cs.deleteContent("/updatefolder1");
         cs.closeSession();
@@ -1136,7 +1135,7 @@ public class WCMContentServiceTest {
 
         cs = repos.createContentSession("admin", "admin");
 
-        WCMBinaryDocument bin = cs.createBinaryDocument("testupdate6", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument bin = cs.createBinaryDocument("testupdate6", "/", mimeType, fileName, content);
         Assert.assertEquals("testupdate6", bin.getId());
         Assert.assertEquals("/testupdate6", bin.getPath());
         Assert.assertEquals(size, bin.getSize());
@@ -1159,31 +1158,31 @@ public class WCMContentServiceTest {
 
         WCMTextDocument doc, doc2;
 
-        cs.createTextDocument("testupdate7", "/", "This is a test content");
+        cs.createTextDocument("testupdate7", "/", "text/plain", "This is a test content");
         cs.createContentAce("/testupdate7", "admin", WCMPrincipalType.USER, WCMPermissionType.ALL);
         cs.createContentComment("/testupdate7", "This is a test comment");
-        cs.createTextDocument("testupdate7", "es", "/", "Este es un contenido relacionado");
+        cs.createTextDocument("testupdate7", "es", "/", "text/plain", "Este es un contenido relacionado");
         doc = (WCMTextDocument)cs.createContentProperty("/testupdate7", "test", "test property");
         doc2 = (WCMTextDocument)cs.getContent("/testupdate7", "es");
 
         Assert.assertEquals("testupdate7", doc.getId());
         Assert.assertEquals("/testupdate7", doc.getPath());
-        Assert.assertEquals("This is a test content", doc.getContent());
+        Assert.assertEquals("This is a test content", doc.getContentAsString());
         Assert.assertEquals(1, doc.getAcl().getAces().size());
         Assert.assertEquals(1, doc.getComments().size());
         Assert.assertEquals("test property", doc.getProperties().get("test"));
-        Assert.assertEquals("Este es un contenido relacionado", doc2.getContent());
+        Assert.assertEquals("Este es un contenido relacionado", doc2.getContentAsString());
 
         cs.createFolder("subfolder7", "/");
         doc = (WCMTextDocument)cs.updateContentPath("/testupdate7", "/subfolder7");
         doc2 = (WCMTextDocument)cs.getContent("/subfolder7/testupdate7", "es");
         Assert.assertEquals("testupdate7", doc.getId());
         Assert.assertEquals("/subfolder7/testupdate7", doc.getPath());
-        Assert.assertEquals("This is a test content", doc.getContent());
+        Assert.assertEquals("This is a test content", doc.getContentAsString());
         Assert.assertEquals(1, doc.getAcl().getAces().size());
         Assert.assertEquals(1, doc.getComments().size());
         Assert.assertEquals("test property", doc.getProperties().get("test"));
-        Assert.assertEquals("Este es un contenido relacionado", doc2.getContent());
+        Assert.assertEquals("Este es un contenido relacionado", doc2.getContentAsString());
 
         cs.deleteContent("/subfolder7");
         cs.deleteContent(doc2.getPath());
@@ -1238,7 +1237,7 @@ public class WCMContentServiceTest {
     // By default "lucas" user has not READ rights on default root repository
     public void updateTextDocumentFailsIfUserDoesntHaveRights() throws Exception {
         cs = repos.createContentSession("admin", "admin");
-        cs.createTextDocument("update5", "es", "/", "Este es un contenido de test");
+        cs.createTextDocument("update5", "es", "/", "text/plain", "Este es un contenido de test");
         cs.closeSession();
 
         cs = repos.createContentSession("admin", "admin");
@@ -1269,7 +1268,7 @@ public class WCMContentServiceTest {
         String mimeType = "application/pdf";
 
         cs = repos.createContentSession("admin", "admin");
-        WCMBinaryDocument update6 = cs.createBinaryDocument("update6", "en", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument update6 = cs.createBinaryDocument("update6", "en", "/", mimeType, fileName, content);
 
         content = (FileInputStream) Thread.currentThread().getContextClassLoader().getResourceAsStream("/wcm-whiteboard.jpg");
         size = content.available();
@@ -1277,7 +1276,6 @@ public class WCMContentServiceTest {
         mimeType = "image/jpeg";
 
         update6.setContent(content);
-        update6.setSize(size);
         update6.setFileName(fileName);
         update6.setMimeType(mimeType);
         update6 = cs.updateBinaryDocument("/update6", update6);
@@ -1291,9 +1289,10 @@ public class WCMContentServiceTest {
         Assert.assertEquals(fileName, update6.getFileName());
         Assert.assertEquals(size, update6.getSize());
         Assert.assertEquals(mimeType, update6.getMimeType());
-        Assert.assertFalse(update6.getContent() == null);
+        InputStream in = update6.getContentAsInputStream();
+        Assert.assertNotNull(in);
 
-        byte[] file = toByteArray(update6.getContent());
+        byte[] file = toByteArray(in);
         Assert.assertEquals(update6.getSize(), file.length);
 
         cs.deleteContent("/update6");
@@ -1309,7 +1308,7 @@ public class WCMContentServiceTest {
         String mimeType = "application/pdf";
 
         cs = repos.createContentSession("admin", "admin");
-        WCMBinaryDocument update7 = cs.createBinaryDocument("update7", "en", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument update7 = cs.createBinaryDocument("update7", "en", "/", mimeType, fileName, content);
 
         content = (FileInputStream) Thread.currentThread().getContextClassLoader().getResourceAsStream("/wcm-whiteboard.jpg");
         size = content.available();
@@ -1318,7 +1317,6 @@ public class WCMContentServiceTest {
 
         update7.setLocale("es");
         update7.setContent(content);
-        update7.setSize(size);
         update7.setFileName(fileName);
         update7.setMimeType(mimeType);
 
@@ -1356,15 +1354,6 @@ public class WCMContentServiceTest {
         }
 
         try {
-            update7.setSize(0);
-            cs.updateBinaryDocument("/update7", update7);
-        } catch (Exception e) {
-            // Expected to fail...
-            fail = true;
-            update7.setSize(size);
-        }
-
-        try {
             update7.setFileName(null);
             cs.updateBinaryDocument("/update7", update7);
         } catch (Exception e) {
@@ -1398,7 +1387,7 @@ public class WCMContentServiceTest {
         String mimeType = "application/pdf";
 
         cs = repos.createContentSession("admin", "admin");
-        WCMBinaryDocument update8 = cs.createBinaryDocument("update8", "en", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument update8 = cs.createBinaryDocument("update8", "en", "/", mimeType, fileName, content);
 
         content = (FileInputStream) Thread.currentThread().getContextClassLoader().getResourceAsStream("/wcm-whiteboard.jpg");
         size = content.available();
@@ -1407,7 +1396,6 @@ public class WCMContentServiceTest {
 
         update8.setLocale("es");
         update8.setContent(content);
-        update8.setSize(size);
         update8.setFileName(fileName);
         update8.setMimeType(mimeType);
 
@@ -1437,7 +1425,7 @@ public class WCMContentServiceTest {
         String mimeType = "application/pdf";
 
         cs = repos.createContentSession("admin", "admin");
-        WCMBinaryDocument update9 = cs.createBinaryDocument("update9", "en", "/", mimeType, size, fileName, content);
+        WCMBinaryDocument update9 = cs.createBinaryDocument("update9", "en", "/", mimeType, fileName, content);
         cs.closeSession();
 
         cs = repos.createContentSession("admin", "admin");
@@ -1449,7 +1437,6 @@ public class WCMContentServiceTest {
 
         update9.setLocale("es");
         update9.setContent(content);
-        update9.setSize(size);
         update9.setFileName(fileName);
         update9.setMimeType(mimeType);
 
@@ -1489,12 +1476,11 @@ public class WCMContentServiceTest {
         String mimeType3 = "image/jpeg";
 
         cs = repos.createContentSession("admin", "admin");
-        cs.createBinaryDocument("update10en", "en", "/", mimeType, size, fileName, content);
-        WCMBinaryDocument update10es = cs.createBinaryDocument("update10es", "es", "/", mimeType2, size2, fileName2, content2);
+        cs.createBinaryDocument("update10en", "en", "/", mimeType, fileName, content);
+        WCMBinaryDocument update10es = cs.createBinaryDocument("update10es", "es", "/", mimeType2, fileName2, content2);
         cs.createContentRelation("/update10en", "/update10es", "es");
 
         update10es.setContent(content3);
-        update10es.setSize(size3);
         update10es.setFileName(fileName3);
         update10es.setMimeType(mimeType3);
 
@@ -1503,7 +1489,7 @@ public class WCMContentServiceTest {
 
         Assert.assertTrue(obj.equals(bin));
 
-        byte[] file = toByteArray(((WCMBinaryDocument) obj).getContent());
+        byte[] file = toByteArray(((WCMBinaryDocument) obj).getContentAsInputStream());
         Assert.assertEquals(bin.getSize(), file.length);
 
         cs.deleteContent("/update10es");
@@ -1927,7 +1913,7 @@ public class WCMContentServiceTest {
     public void putContentCategory() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("testcat", "/", "This is a test of attached category to a content");
+        cs.createTextDocument("testcat", "/", "text/plain", "This is a test of attached category to a content");
         cs.createCategory("world11", "World category", "/");
         cs.createCategory("sports1", "Sports category", "/");
         cs.putContentCategory("/testcat", "/world11");
@@ -2006,9 +1992,9 @@ public class WCMContentServiceTest {
         cs = repos.createContentSession("admin", "admin");
 
         cs.createCategory("testcategory", "Test Category", "/");
-        cs.createTextDocument("testcat1", "/", "This is test content for category 1");
-        cs.createTextDocument("testcat2", "/", "This is test content for category 2");
-        cs.createTextDocument("testcat3", "/", "This is test content for category 3");
+        cs.createTextDocument("testcat1", "/", "text/plain", "This is test content for category 1");
+        cs.createTextDocument("testcat2", "/", "text/plain", "This is test content for category 2");
+        cs.createTextDocument("testcat3", "/", "text/plain", "This is test content for category 3");
 
         cs.putContentCategory("/testcat1", "/testcategory");
         cs.putContentCategory("/testcat2", "/testcategory");
@@ -2110,8 +2096,8 @@ public class WCMContentServiceTest {
         int news = 1;
         for (int site = 1; site <= 3; site++) {
             for (int i = 1; i <= 4; i++) {
-                cs.createTextDocument("new" + news, "es", "/site" + site, "Esta es la noticia " + news);
-                cs.createTextDocument("new" + news, "en", "/site" + site, "This is the news " + news);
+                cs.createTextDocument("new" + news, "es", "/site" + site, "text/plain", "Esta es la noticia " + news);
+                cs.createTextDocument("new" + news, "en", "/site" + site, "text/plain", "This is the news " + news);
                 news++;
             }
         }
@@ -2231,7 +2217,7 @@ public class WCMContentServiceTest {
     public void createComment() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("testcomment", "/", "This is a text with comments");
+        cs.createTextDocument("testcomment", "/", "text/plain", "This is a text with comments");
         WCMTextDocument c = (WCMTextDocument)cs.createContentComment("/testcomment", "This is comment 1");
         Assert.assertEquals("This is comment 1", c.getComments().get(0).getComment());
 
@@ -2289,7 +2275,7 @@ public class WCMContentServiceTest {
     public void deleteComment() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("testcomment2", "/", "This is a text with comments");
+        cs.createTextDocument("testcomment2", "/", "text/plain", "This is a text with comments");
         WCMTextDocument d = (WCMTextDocument)cs.createContentComment("/testcomment2", "This is comment 1");
         WCMComment c = d.getComments().get(0);
 
@@ -2309,7 +2295,7 @@ public class WCMContentServiceTest {
     public void createContentProperty() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("testproperty1", "/", "This is a text with properties");
+        cs.createTextDocument("testproperty1", "/", "text/plain", "This is a text with properties");
         cs.createContentProperty("/testproperty1", "title", "This is the title");
         cs.createContentProperty("/testproperty1", "description", "This is a description");
         WCMTextDocument obj = (WCMTextDocument) cs.createContentProperty("/testproperty1", "kpi", "10");
@@ -2377,7 +2363,7 @@ public class WCMContentServiceTest {
     public void updateContentProperty() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("testproperty2", "/", "This is a text with properties");
+        cs.createTextDocument("testproperty2", "/", "text/plain", "This is a text with properties");
         cs.createContentProperty("/testproperty2", "title", "This is the title");
         cs.createContentProperty("/testproperty2", "description", "This is a description");
         cs.createContentProperty("/testproperty2", "kpi", "10");
@@ -2446,7 +2432,7 @@ public class WCMContentServiceTest {
     public void deleteContentProperty() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        cs.createTextDocument("testproperty3", "/", "This is a text with properties");
+        cs.createTextDocument("testproperty3", "/", "text/plain", "This is a text with properties");
         cs.createContentProperty("/testproperty3", "title", "This is the title");
         cs.createContentProperty("/testproperty3", "description", "This is a description");
         WCMTextDocument obj = (WCMTextDocument) cs.createContentProperty("/testproperty3", "kpi", "10");
@@ -2626,7 +2612,7 @@ public class WCMContentServiceTest {
     public void getVersions() throws Exception {
         cs = repos.createContentSession("admin", "admin");
 
-        WCMTextDocument doc = cs.createTextDocument("testversions", "/", "This is Version 1");
+        WCMTextDocument doc = cs.createTextDocument("testversions", "/", "text/plain", "This is Version 1");
 
         Assert.assertEquals(1, cs.getVersions("/testversions").size());
 
@@ -2702,7 +2688,7 @@ public class WCMContentServiceTest {
         cs = repos.createContentSession("admin", "admin");
 
         // Version 1.0
-        WCMTextDocument doc = cs.createTextDocument("testversions3", "/", "This is Version 1");
+        WCMTextDocument doc = cs.createTextDocument("testversions3", "/", "text/plain", "This is Version 1");
 
         // Version 1.1
         doc.setContent("This is Version 2");
@@ -2718,19 +2704,19 @@ public class WCMContentServiceTest {
 
         cs.restore("/testversions3", "1.0");
         doc = (WCMTextDocument) cs.getContent("/testversions3");
-        Assert.assertEquals("This is Version 1", doc.getContent());
+        Assert.assertEquals("This is Version 1", doc.getContentAsString());
 
         cs.restore("/testversions3", "1.1");
         doc = (WCMTextDocument) cs.getContent("/testversions3");
-        Assert.assertEquals("This is Version 2", doc.getContent());
+        Assert.assertEquals("This is Version 2", doc.getContentAsString());
 
         cs.restore("/testversions3", "1.2");
         doc = (WCMTextDocument) cs.getContent("/testversions3");
-        Assert.assertEquals("This is Version 3", doc.getContent());
+        Assert.assertEquals("This is Version 3", doc.getContentAsString());
 
         cs.restore("/testversions3", "1.3");
         doc = (WCMTextDocument) cs.getContent("/testversions3");
-        Assert.assertEquals("This is Version 4", doc.getContent());
+        Assert.assertEquals("This is Version 4", doc.getContentAsString());
 
         cs.deleteContent("/testversions3");
         cs.closeSession();
@@ -2804,7 +2790,7 @@ public class WCMContentServiceTest {
         cs = repos.createContentSession("admin", "admin");
 
         // Version 1.0
-        WCMTextDocument doc = cs.createTextDocument("testversions5", "/", "This is Version 1");
+        WCMTextDocument doc = cs.createTextDocument("testversions5", "/", "text/plain", "This is Version 1");
 
         // Version 1.1
         doc.setContent("This is Version 2");

--- a/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/model/TreeContent.java
+++ b/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/model/TreeContent.java
@@ -93,7 +93,7 @@ public class TreeContent {
 
     public String getText() {
         if (text == null && getTextContent() != null) {
-            text = getTextContent().getContent();
+            text = getTextContent().getContentAsString();
         }
         return text;
     }

--- a/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/servlet/WcmContent.java
+++ b/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/servlet/WcmContent.java
@@ -79,7 +79,7 @@ public class WcmContent extends HttpServlet {
                 WCMTextDocument t = (WCMTextDocument)content;
                 resp.setContentType("text/html");
                 PrintWriter out = resp.getWriter();
-                out.print(t.getContent());
+                out.print(t.getContentAsString());
                 out.flush();
                 out.close();
             } else {

--- a/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/servlet/WcmResource.java
+++ b/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/servlet/WcmResource.java
@@ -85,7 +85,7 @@ public class WcmResource extends HttpServlet {
                 resp.setStatus(HttpServletResponse.SC_OK);
 
                 byte[] buffer = new byte[16384];
-                InputStream in = b.getContent();
+                InputStream in = b.getContentAsInputStream();
                 BufferedOutputStream out = new BufferedOutputStream(resp.getOutputStream());
                 for (int length = 0; (length = in.read(buffer)) > 0;) {
                     out.write(buffer, 0, length);

--- a/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/tests/performance/CreateBinary.java
+++ b/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/tests/performance/CreateBinary.java
@@ -110,7 +110,7 @@ public class CreateBinary extends HttpServlet {
             WCMObject _c = null;
             try {
                 if (id != null && locale != null && location != null && file != null)
-                    _c = cs.createBinaryDocument(id, locale, location, file.getContentType(), file.getSize(), file.getName(), file.getInputStream());
+                    _c = cs.createBinaryDocument(id, locale, location, file.getContentType(), file.getName(), file.getInputStream());
             } catch (WCMContentException e) {
                 log.error(e.getMessage());
                 out.println(e.getMessage());

--- a/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/tests/performance/CreateText.java
+++ b/gatein-wcm-ui/src/main/java/org/gatein/wcm/ui/tests/performance/CreateText.java
@@ -55,8 +55,9 @@ public class CreateText extends HttpServlet {
         String locale = req.getParameter("locale");
         String location = req.getParameter("location");
         String text = req.getParameter("text");
+        String mimeType = "text/html";
 
-        resp.setContentType("text/html");
+        resp.setContentType(mimeType);
         PrintWriter out = resp.getWriter();
 
         // Connect form
@@ -69,7 +70,7 @@ public class CreateText extends HttpServlet {
         } else {
             WCMObject _c = null;
             try {
-                _c = cs.createTextDocument(id, locale, location, text);
+                _c = cs.createTextDocument(id, locale, location, mimeType, text);
             } catch (WCMContentException e) {
                 log.error(e.getMessage());
                 out.println(e.getMessage());


### PR DESCRIPTION
extend WCMBinaryDocument

This proposal makes it possible to avoid using potentially memory-expensive String getContent() of WCMTextDocument. The API user can choose to use getContentAsReader() with smaller memory footprint. 

WCMTextDocument was made a subclass of WCMBinaryDocument so that all binary doc functionality is available also in WCMTextDocument.

WCMBinaryDocument size attribute was made read-only. The size is get/set automatically based on the length of the underlying InputStream.

WCMBinaryDocument encoding attribute was added to make bin -> text transformations possible. ATM, it is set internally to default UTF-8 encoding. I find myself this part of the implementation as further improvable. I'd do that if this proposal is accepted as a whole.
